### PR TITLE
Fixed bug - Error in ct*2 calculation for parts using peak2.

### DIFF
--- a/CLA_Classifier.R
+++ b/CLA_Classifier.R
@@ -1343,7 +1343,7 @@ server <- function(input, output) {
         }
       }
       
-      n <-  c2;
+      n <-  c2-1;
       n1L <- {n-1}*lengthofepisode+1
       n2L <- lengthofepisode*n
       tn <- abftest$traces[1,n1L:n2L];
@@ -2847,7 +2847,7 @@ server <- function(input, output) {
               }
             }
             
-            n <-  c2;
+            n <-  c2-1;
             n1L <- {n-1}*lengthofepisode+1
             n2L <- lengthofepisode*n
             tn <- abftest$traces[1,n1L:n2L];


### PR DESCRIPTION
Corrected index error resulting in CT*2+1 being used for calculation of ephys properties where peak2 variable was concerned.